### PR TITLE
Deps fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
     "commander": "^11.1.0",
     "ethers": "6.8.1",
     "node-fetch": "^3.3.2",
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.8.5",
+    "chokidar": "^3.5.3",
+    "dotenv": "^16.3.1",
+    "patch-package": "^8.0.0",
+    "postinstall-postinstall": "^2.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
@@ -40,10 +44,6 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/shelljs": "^0.8.14",
-    "chokidar": "^3.5.3",
-    "dotenv": "^16.3.1",
-    "patch-package": "^8.0.0",
-    "postinstall-postinstall": "^2.1.0",
     "rollup": "^3.29.4",
     "rollup-plugin-add-shebang": "^0.3.1",
     "typescript": "^5.2.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
         file: path.resolve("bin", "cli.js"),
         format: 'es'
     },
-    external: [...builtinModules, "shelljs", "commander", "ethers", "chokidar", "chalk", "node-fetch"],
+    external: [...builtinModules, "shelljs", "commander", "ethers", "chokidar", "chalk", "node-fetch", "dotenv", "patch-package", "postinstall-postinstall"],
     plugins: [
         nodeResolve(),
         json(),


### PR DESCRIPTION
# Changes
This includes taking some deps from `devDependencies` to `dependencies`, which are necessary for tool functioning.

With this change, I tested successfully releasing on npm, and then installing from there.