### PR TITLE
Pathing fix for Path module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polygonlabs/dapp-launchpad",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI tool to initialise a fully-integrated EVM-compatible dApp, create a development environment, and deploy everything to production.",
   "license": "MIT",
   "bin": {

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -43,7 +43,7 @@ export const fixDAppScaffoldConfig = (projectRootDir: string) => {
                 Object
                     .entries((config.template.filesAndDirs as any)[masterDirType])
                     .forEach(([subDirType, pathRelative]) => {
-                        (config.template.filesAndDirs as any)[masterDirType][subDirType] = path.resolve(...(pathRelative as string).split("/"));
+                        (config.template.filesAndDirs as any)[masterDirType][subDirType] = path.join(...(pathRelative as string).split("/"));
                     });
             });
 


### PR DESCRIPTION
# Fixes
This PR fixes the paths in the dApp Launchpad config files.

Previously, the incorrect absolute path was being used because of incorrect cwd. Now, it's replaced with correct relative path.